### PR TITLE
Switch backend logging to timbre

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -12,6 +12,7 @@
 
            ;; Logging
            ch.qos.logback/logback-classic {:mvn/version "1.5.16"}
+           com.taoensso/timbre {:mvn/version "6.2.2"}
 
            ;; Data coercion
            luminus-transit/luminus-transit {:mvn/version "0.1.6"

--- a/env/dev/clj/hc/hospital/env.clj
+++ b/env/dev/clj/hc/hospital/env.clj
@@ -1,14 +1,16 @@
 (ns hc.hospital.env
   (:require
-    [clojure.tools.logging :as log]
+    [taoensso.timbre :as log]
+    [hc.hospital.logging :as logging]
     [hc.hospital.dev-middleware :refer [wrap-dev]]))
 
 (def defaults
   {:init       (fn []
+                 (logging/configure-logging!)
                  (log/info "\n-=[hospital starting using the development or test profile]=-"))
    :start      (fn []
-                 (log/info "\n-=[hospital started successfully using the development or test profile]=-"))
+                (log/info "\n-=[hospital started successfully using the development or test profile]=-"))
    :stop       (fn []
-                 (log/info "\n-=[hospital has shut down successfully]=-"))
+                (log/info "\n-=[hospital has shut down successfully]=-"))
    :middleware wrap-dev
    :opts       {:profile       :dev}})

--- a/env/prod/clj/hc/hospital/env.clj
+++ b/env/prod/clj/hc/hospital/env.clj
@@ -1,12 +1,14 @@
 (ns hc.hospital.env
-  (:require [clojure.tools.logging :as log]))
+  (:require [taoensso.timbre :as log]
+            [hc.hospital.logging :as logging]))
 
 (def defaults
   {:init       (fn []
+                 (logging/configure-logging!)
                  (log/info "\n-=[hospital starting]=-"))
    :start      (fn []
-                 (log/info "\n-=[hospital started successfully]=-"))
+                (log/info "\n-=[hospital started successfully]=-"))
    :stop       (fn []
-                 (log/info "\n-=[hospital has shut down successfully]=-"))
+                (log/info "\n-=[hospital has shut down successfully]=-"))
    :middleware (fn [handler _] handler)
    :opts       {:profile :prod}})

--- a/src/clj/hc/hospital/core.clj
+++ b/src/clj/hc/hospital/core.clj
@@ -1,6 +1,6 @@
 (ns hc.hospital.core
   (:require
-   [clojure.tools.logging :as log]
+   [taoensso.timbre :as log]
    [integrant.core :as ig]
    [hc.hospital.web.routes.pages]
    [hc.hospital.config :as config]

--- a/src/clj/hc/hospital/db/his_patient_queries.clj
+++ b/src/clj/hc/hospital/db/his_patient_queries.clj
@@ -1,5 +1,5 @@
 (ns hc.hospital.db.his-patient-queries
-  (:require [clojure.tools.logging :as log]))
+  (:require [taoensso.timbre :as log]))
 
 ;; 这些函数期望接收一个 oracle-query-fn，该函数应与 oracle_his_queries.sql 文件绑定
 ;; 并且配置为 hugsql.core/def-db-fns 生成的函数集合中的特定查询函数。

--- a/src/clj/hc/hospital/db/oracle.clj
+++ b/src/clj/hc/hospital/db/oracle.clj
@@ -1,7 +1,7 @@
 (ns hc.hospital.db.oracle
   (:require
    [integrant.core :as ig]
-   [clojure.tools.logging :as log]
+   [taoensso.timbre :as log]
    [conman.core :as conman]))
 
 ;; Conman version of init-key for :db.oracle/connection

--- a/src/clj/hc/hospital/logging.clj
+++ b/src/clj/hc/hospital/logging.clj
@@ -1,0 +1,33 @@
+(ns hc.hospital.logging
+  (:require [taoensso.timbre :as timbre]
+            [clojure.java.io :as io])
+  (:import [java.time Instant ZoneId LocalDate]
+           [java.time.format DateTimeFormatter]))
+
+(def ^:private date-format (DateTimeFormatter/ofPattern "yyyy-MM-dd"))
+
+(defn- log-file-path
+  [dir prefix ^Instant inst]
+  (let [ld (.format (.atZone inst (ZoneId/systemDefault)) date-format)]
+    (str (or dir "log") "/" (or prefix "hospital") "-" ld ".log")))
+
+(defn daily-file-appender
+  "Returns a Timbre appender that writes logs to a daily rolling file."
+  [& [{:keys [dir prefix] :or {dir "log" prefix "hospital"}}]]
+  (let [lock (Object.)]
+    {:enabled? true
+     :fn (fn [{:keys [timestamp_ output_]}]
+           (let [^Instant inst (force timestamp_)
+                 out (force output_)
+                 path (log-file-path dir prefix inst)]
+             (io/make-parents path)
+             (locking lock
+               (spit path out :append true))))}))
+
+(defn configure-logging!
+  "Configure Timbre to log to console and daily rolling file."
+  ([] (configure-logging! {}))
+  ([opts]
+   (timbre/merge-config!
+    {:appenders {:println (timbre/println-appender)
+                 :daily-file (apply daily-file-appender [opts])}})))

--- a/src/clj/hc/hospital/web/controllers/auth.clj
+++ b/src/clj/hc/hospital/web/controllers/auth.clj
@@ -1,6 +1,6 @@
 (ns hc.hospital.web.controllers.auth
   (:require
-   [clojure.tools.logging :as ctl]
+   [taoensso.timbre :as ctl]
    [hc.hospital.db.doctor :as doctor.db]
    [hc.hospital.web.pages.layout :as layout]
    [ring.util.http-response :as http-response]))

--- a/src/clj/hc/hospital/web/controllers/patient_api.clj
+++ b/src/clj/hc/hospital/web/controllers/patient_api.clj
@@ -3,7 +3,7 @@
    [cheshire.core :as cheshire]
    [cheshire.core :as cheshire]
    [clojure.string :as str]
-   [clojure.tools.logging :as log]
+   [taoensso.timbre :as log :refer [spy]]
    [ring.util.http-response :as http-response]
    [hc.hospital.db.his-patient-queries :as his-queries]) ; 新增的 require
   (:import

--- a/src/clj/hc/hospital/web/middleware/auth.clj
+++ b/src/clj/hc/hospital/web/middleware/auth.clj
@@ -4,7 +4,7 @@
    [buddy.auth.accessrules :as accessrules]
    [buddy.auth.backends.session :as session]
    [buddy.auth.middleware :as auth-middleware]
-   [clojure.tools.logging :as log]
+   [taoensso.timbre :as log]
    [ring.util.http-response :as http-response])) ; Added for redirect
 
 (defn on-error [request _response]

--- a/src/clj/hc/hospital/web/middleware/exception.clj
+++ b/src/clj/hc/hospital/web/middleware/exception.clj
@@ -1,6 +1,6 @@
 (ns hc.hospital.web.middleware.exception
   (:require
-    [clojure.tools.logging :as log]
+    [taoensso.timbre :as log]
     [reitit.ring.middleware.exception :as exception]))
 
 (defn handler [message status exception request]

--- a/src/clj/hc/hospital/web/routes/pages.clj
+++ b/src/clj/hc/hospital/web/routes/pages.clj
@@ -1,6 +1,6 @@
 (ns hc.hospital.web.routes.pages
   (:require
-   [clojure.tools.logging :as log]
+   [taoensso.timbre :as log]
    [hc.hospital.web.controllers.auth :as auth] ; Added auth controller
    [hc.hospital.web.middleware.auth :refer [wrap-restricted]]
    [hc.hospital.web.middleware.exception :as exception]


### PR DESCRIPTION
## Summary
- switch from `clojure.tools.logging` to `timbre`
- add `timbre` dependency
- configure timbre to write daily rolling log files

## Testing
- `clojure -M:test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684a61a033b48327a6ff5e6765fba745