### PR TITLE
Use Form binding for QR scan modal

### DIFF
--- a/src/cljs/hc/hospital/components/qr_scan_modal.cljs
+++ b/src/cljs/hc/hospital/components/qr_scan_modal.cljs
@@ -1,25 +1,26 @@
 (ns hc.hospital.components.qr-scan-modal
   (:require
-   ["antd" :refer [Modal Input Button]]
-   [reagent.core :as r]
-   [re-frame.core :as rf])) ; Added re-frame for potential future state management
+   ["antd" :refer [Modal Input Form]]))
 
 ;; 二维码扫描模态框组件
 ;; props:
 ;; - visible? (boolean): 控制模态框是否可见
-;; - input-value (string): 输入框的当前值 (由 re-frame 控制)
-;; - on-input-change (function): 输入框内容变化时的回调函数
-;; - on-ok (function): 点击确定按钮时的回调函数
+;; - on-ok (function): 点击确定按钮时的回调函数，接收输入的患者ID
 ;; - on-cancel (function): 点击取消按钮或关闭模态框时的回调函数
-(defn qr-scan-modal [{:keys [visible? input-value on-input-change on-ok on-cancel]}]
-  [:> Modal {:title "扫码签到"
-             :open visible?
-             :onOk on-ok ; 直接使用传递过来的 on-ok 函数
-             :onCancel on-cancel
-             :okText "确定"
-             :cancelText "取消"
-             :destroyOnClose true} ; 关闭时销毁内部组件状态
-   [:div {:style {:padding "20px"}} ; 增加一些内边距
-    [:> Input {:placeholder "请输入患者ID"
-               :value input-value ; 绑定到 props 传入的 input-value
-               :on-change on-input-change}]]]) ; 调用 props 传入的 on-input-change
+(defn qr-scan-modal [{:keys [visible? on-ok on-cancel]}]
+  (let [[form] (Form.useForm)]
+    [:> Modal {:title "扫码签到"
+               :open visible?
+               :onOk (fn [] (.submit form))
+               :onCancel on-cancel
+               :okText "确定"
+               :cancelText "取消"
+               :destroyOnClose true}
+     [:> Form {:form form
+               :layout "vertical"
+               :onFinish (fn [values]
+                           (on-ok (aget values "patient-id")))}
+      [:> Form.Item {:name "patient-id"}
+       [:> Input {:placeholder "请输入患者ID"
+                  :autoFocus true
+                  :onPressEnter (fn [_] (.submit form))}]]]]))

--- a/src/cljs/hc/hospital/pages/anesthesia_home.cljs
+++ b/src/cljs/hc/hospital/pages/anesthesia_home.cljs
@@ -93,8 +93,7 @@
 
 (defn anesthesia-home-page []
   (let [active-tab @(rf/subscribe [::subs/active-tab])
-        qr-modal-visible? @(rf/subscribe [::subs/qr-scan-modal-visible?])
-        qr-input-value @(rf/subscribe [::subs/qr-scan-input-value])]
+        qr-modal-visible? @(rf/subscribe [::subs/qr-scan-modal-visible?])]
     [:> Layout {:style {:minHeight "100vh"}}
      [sider-bar active-tab]
      [:> Layout {:style {:display "flex" :flexDirection "column"}}
@@ -104,9 +103,7 @@
       ;; 在页面底部渲染二维码扫描模态框
       (when qr-modal-visible?
         [qr-scan-modal {:visible? qr-modal-visible?
-                        :input-value qr-input-value
-                        :on-input-change (fn [e] (rf/dispatch [::events/set-qr-scan-input (-> e .-target .-value)]))
-                        :on-ok (fn []
+                        :on-ok (fn [patient-id]
                                  ;; 点击确定时，派发事件以通过API查询HIS中的患者信息
-                                 (rf/dispatch [::events/find-patient-by-id-in-his qr-input-value]))
+                                 (rf/dispatch [::events/find-patient-by-id-in-his patient-id]))
                         :on-cancel #(rf/dispatch [::events/close-qr-scan-modal])}])]]))


### PR DESCRIPTION
## Summary
- refactor QR scan modal to use antd Form binding instead of a controlled input
- adjust anesthesia home page to retrieve the patient ID from the modal

## Testing
- `make test` *(returns 'up to date')*
- `clj -M:test -m kaocha.runner` *(fails: `clj: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a72a39ab08327bdb455a04ef679a1