### PR TITLE
调整术前诊断与拟施手术输入框为单行

### DIFF
--- a/src/cljs/hc/hospital/pages/anesthesia.cljs
+++ b/src/cljs/hc/hospital/pages/anesthesia.cljs
@@ -152,14 +152,12 @@
                                 (rf/dispatch [::events/update-canonical-assessment-section :基本信息 values-clj])))
                   :key patient-id} ; Ensure form re-initializes when patient changes
          [:> Form.Item {:label "术前诊断" :name :术前诊断}
-          [:> Input.TextArea {:placeholder "请输入术前诊断"
-                              :rows 2
-                              :onChange #(rf/dispatch [::events/update-canonical-assessment-field [:基本信息 :术前诊断] (-> % .-target .-value)])}]]
+          [:> Input {:placeholder "请输入术前诊断"
+                     :onChange #(rf/dispatch [::events/update-canonical-assessment-field [:基本信息 :术前诊断] (-> % .-target .-value)])}]]
 
          [:> Form.Item {:label "拟施手术" :name :拟施手术}
-          [:> Input.TextArea {:placeholder "请输入拟施手术"
-                              :rows 2
-                              :onChange #(rf/dispatch [::events/update-canonical-assessment-field [:基本信息 :拟施手术] (-> % .-target .-value)])}]]]]
+          [:> Input {:placeholder "请输入拟施手术"
+                     :onChange #(rf/dispatch [::events/update-canonical-assessment-field [:基本信息 :拟施手术] (-> % .-target .-value)])}]]]]
        [:> Empty {:description "请先选择患者或患者无基本信息"}])]))
 
 (defn- general-condition-card "显示一般情况" []


### PR DESCRIPTION
## Summary
- 调整"术前诊断"和"拟施手术"字段使用單行 `Input`，避免过多空白

## Testing
- `yarn install`
- `npx shadow-cljs compile app` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684ae7f3071c8327b2cb622097c39e25