### PR TITLE
调整过滤区域按钮排列

### DIFF
--- a/src/cljs/hc/hospital/pages/anesthesia.cljs
+++ b/src/cljs/hc/hospital/pages/anesthesia.cljs
@@ -44,8 +44,12 @@
                                    {:value "已驳回" :label "已驳回"}
                                    {:value "已暂缓" :label "已暂缓"}]]
     [:div {:style {:padding "16px" :borderBottom "1px solid #f0f0f0"}}
-     ;; 按钮组
-     [:> Space {:style {:marginBottom "16px" :width "100%"}}
+     ;; 按钮组，两侧对齐
+     [:> Space {:style {:marginBottom "16px"
+                        :width "100%"
+                        :display "flex"
+                        :justifyContent "space-between"
+                        :alignItems "center"}}
       [:> Button {:type "primary"
                   :icon (r/as-element [:> SyncOutlined])
                   :onClick #(rf/dispatch [::events/sync-applications]) ; 您需要定义此事件


### PR DESCRIPTION
## Summary
- 调整`patient-list-filters`中按钮的布局，使"同步申请"和"扫码签到"分列左右

## Testing
- `yarn install`
- `npx shadow-cljs compile app` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684cd589c39483278154ca59792ae066