### PR TITLE
Fix double scrollbars in doctor assessment page

### DIFF
--- a/resources/public/css/screen.css
+++ b/resources/public/css/screen.css
@@ -1,0 +1,8 @@
+html, body, #app {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  overflow: hidden;
+}

--- a/src/cljs/hc/hospital/pages/anesthesia_home.cljs
+++ b/src/cljs/hc/hospital/pages/anesthesia_home.cljs
@@ -89,7 +89,7 @@
 
   (let [role (:role @(rf/subscribe [::subs/current-doctor]))]
     [:> Layout {:style {:height "calc(100vh - 64px)"
-                        :overflow "auto"
+                        :overflow "hidden"
                         :background "#f0f2f5"}}
      [:div {:style {:padding "24px"}}
       (case active-tab


### PR DESCRIPTION
## Summary
- hide outer scroll container in doctor interface
- set base CSS to stop body scrolling

## Testing
- `yarn install`
- `npx shadow-cljs compile app` *(fails: Network is unreachable)*
- `clj -M:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1f1a2a60832783c45ede7848ddf7