### PR TITLE
实现前端路由与历史联动

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -7,8 +7,9 @@
                 [cljs-ajax "0.8.4"]
                 [day8.re-frame/http-fx "0.2.4"]
                 [reagent "1.1.0"]
-                [re-frame "1.3.0"]
-                [com.taoensso/timbre "6.2.2"]]
+               [re-frame "1.3.0"]
+               [com.taoensso/timbre "6.2.2"]
+               [metosin/reitit "0.9.1"]]
  :repositories {"clojars" {:url "https://repo.clojars.org/"}}
  :dev-http {8021 "target/browser-test"}
  :builds       {:app {:target     :browser

--- a/src/cljs/hc/hospital/core.cljs
+++ b/src/cljs/hc/hospital/core.cljs
@@ -14,7 +14,8 @@
    ["antd" :as antd :refer [Button Spin ConfigProvider]] ; 引入 ConfigProvider
    ["antd/es/locale/zh_CN" :default zhCN] ; 中文本地化
    ["dayjs/locale/zh-cn"]
-   ["dayjs" :as dayjs]))
+   ["dayjs" :as dayjs]
+   [hc.hospital.router :as router]))
 
 ;; 导入 Ant Design CSS
 ;;(js/require "antd/dist/reset.css")
@@ -79,5 +80,8 @@
       (timbre/info "正常应用初始化：派发 initialize-db 和 check-session 事件。")
       (rf/dispatch-sync [::events/initialize-db])
       (rf/dispatch [::events/check-session])))
+
+  ;; 初始化路由并监听浏览器历史
+  (router/init-router!)
 
   (mount-root))

--- a/src/cljs/hc/hospital/events.cljs
+++ b/src/cljs/hc/hospital/events.cljs
@@ -6,6 +6,7 @@
             [ajax.core :as ajax]
             [clojure.string :as str]
             [hc.hospital.utils :as utils]
+            [hc.hospital.router :as router]
             [taoensso.timbre :as timbre]))
 
 ;; 默认的规范评估数据结构
@@ -379,6 +380,15 @@
 (rf/reg-event-db ::set-active-tab
   (fn [db [_ tab]]
     (assoc-in db [:anesthesia :active-tab] tab))) ; Ensure path is correct
+
+(rf/reg-fx
+  ::navigate-tab
+  (fn [tab]
+    (router/navigate! tab)))
+
+(rf/reg-event-fx ::navigate-tab
+  (fn [{:keys [db]} [_ tab]]
+    {:navigate-tab tab}))
 
 (rf/reg-event-db ::open-user-modal
   (fn [db [_ user-data]]

--- a/src/cljs/hc/hospital/pages/anesthesia_home.cljs
+++ b/src/cljs/hc/hospital/pages/anesthesia_home.cljs
@@ -40,7 +40,7 @@
                                      "settings" "3"
                                      "1")]
                     :onClick (fn [item]
-                               (rf/dispatch [::events/set-active-tab
+                               (rf/dispatch [::events/navigate-tab
                                              (condp = (.-key item)
                                                "1" "patients"
                                                "2" "assessment"

--- a/src/cljs/hc/hospital/router.cljs
+++ b/src/cljs/hc/hospital/router.cljs
@@ -1,0 +1,40 @@
+(ns hc.hospital.router
+  "基于 Reitit 的前端路由管理。"
+  (:require [reitit.frontend :as rf]
+            [reitit.frontend.easy :as rfe]
+            [re-frame.core :as rf-core]
+            [taoensso.timbre :as timbre]
+            [hc.hospital.events :as events]))
+
+(def routes
+  "路由表，定义页面标签与路径的映射。"
+  [["/" {:name :patients}]
+   ["/assessment" {:name :assessment}]
+   ["/settings" {:name :settings}]])
+
+(def router
+  (rf/router routes))
+
+(defn- on-navigate
+  [match]
+  (when match
+    (let [tab (name (get-in match [:data :name]))]
+      (timbre/debug "路由切换:" tab)
+      (rf-core/dispatch [::events/set-active-tab tab]))))
+
+(defn init-router!
+  "初始化路由并开始监听浏览器历史变化。"
+  []
+  (rfe/start! router on-navigate {:use-fragment false}))
+
+(def tab->route
+  {"patients" :patients
+   "assessment" :assessment
+   "settings" :settings})
+
+(defn navigate!
+  "根据标签名导航到相应路径。"
+  [tab]
+  (if-let [route (get tab->route tab)]
+    (rfe/push-state route)
+    (timbre/warn "未知标签" tab)))


### PR DESCRIPTION
## Summary
- 添加 `metosin/reitit` 依赖并使用 `reitit.frontend` 管理浏览器路由
- 初始化路由监听，点击侧边栏菜单时同步浏览器地址

## Testing
- `yarn install`
- `npx shadow-cljs compile app` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684d3b9e85148327ac24961afb8e3afb