### PR TITLE
修复知情同意书更新缺少 assessment_id

### DIFF
--- a/resources/html/report/pre_anesthesia_consent.html
+++ b/resources/html/report/pre_anesthesia_consent.html
@@ -252,7 +252,8 @@
                 fetch(`/api/consent-forms/${assessmentId}`, {
                     method: 'PUT',
                     headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify({pre_anesthesia_form: form.innerHTML})
+                    body: JSON.stringify({assessment_id: parseInt(assessmentId),
+                                         pre_anesthesia_form: form.innerHTML})
                 }).catch(err => console.error('save failed', err));
             };
             form.addEventListener('click', (event) => {

--- a/resources/html/report/sedation_consent.html
+++ b/resources/html/report/sedation_consent.html
@@ -343,7 +343,8 @@
                 fetch(`/api/consent-forms/${assessmentId}`, {
                     method: 'PUT',
                     headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify({sedation_form: form.innerHTML})
+                    body: JSON.stringify({assessment_id: parseInt(assessmentId),
+                                         sedation_form: form.innerHTML})
                 }).catch(err => console.error('save failed', err));
             };
 


### PR DESCRIPTION
## Summary
- 修改镇静和术前麻醉知情同意书页面，在保存时将 `assessment_id` 一并提交

## Testing
- `clojure -M:test` *(fails: Failed to download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684ff8614f3883278ef22a30febc975c