### PR TITLE
修复Ant Design弃用属性

### DIFF
--- a/src/cljs/hc/hospital/components/qr_scan_modal.cljs
+++ b/src/cljs/hc/hospital/components/qr_scan_modal.cljs
@@ -15,7 +15,7 @@
                :onCancel on-cancel
                :okText "确定"
                :cancelText "取消"
-               :destroyOnClose true}
+               :destroyOnHidden true}
      [:> Form {:form form
                :layout "vertical"
                :onFinish (fn [values]

--- a/src/cljs/hc/hospital/pages/anesthesia.cljs
+++ b/src/cljs/hc/hospital/pages/anesthesia.cljs
@@ -722,8 +722,8 @@
                      :title nil
                      :width "100%"
                      :style {:top 0}
-                     :bodyStyle {:padding 0 :height "100vh"}
-                     :destroyOnClose true
+                     :styles {:body {:padding 0 :height "100vh"}}
+                     :destroyOnHidden true
                      :onCancel #(reset! sedation-open? false)}
            [:iframe {:src (str "/report/sedation-consent?assessment-id=" current-assessment-id)
                      :style {:border "none" :width "100%" :height "100%"}}]]
@@ -736,8 +736,8 @@
                      :title nil
                      :width "100%"
                      :style {:top 0}
-                     :bodyStyle {:padding 0 :height "100vh"}
-                     :destroyOnClose true
+                     :styles {:body {:padding 0 :height "100vh"}}
+                     :destroyOnHidden true
                      :onCancel #(reset! talk-open? false)}
            [:iframe {:src (str "/report/pre-anesthesia-consent?assessment-id=" current-assessment-id)
                      :style {:border "none" :width "100%" :height "100%"}}]]


### PR DESCRIPTION
## Summary
- 更新医生端麻醉页面中的 `Modal` 属性，使用 `styles.body` 与 `destroyOnHidden`
- 同步更新二维码扫描模态框组件的相应属性

## Testing
- `yarn install`
- `npx shadow-cljs compile app` *(fails: Network is unreachable)*
- `clj -M:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685026fac9508327888efc49acabf1ca