### PR TITLE
Add extended overview stats

### DIFF
--- a/src/cljs/hc/hospital/db.cljs
+++ b/src/cljs/hc/hospital/db.cljs
@@ -1,4 +1,15 @@
+
 (ns hc.hospital.db)
+
+(def default-overview-stats
+  "首页概览默认统计数据"
+  [{:label "总就诊人数" :value 156 :trend :up :description "比去年增加12人"}
+   {:label "今日患者人数" :value 42 :trend :up :description "比昨日增加3人"}
+   {:label "手术患者人数" :value 18 :trend :down :description "比昨日减少2人"}
+   {:label "已签字人数" :value 15 :trend :up :description "比昨日增加5人"}
+   {:label "糖尿病人数" :value 7 :trend :same :description "与昨日持平"}
+   {:label "高血压人数" :value 9 :trend :up :description "比昨日增加2人"}
+   {:label "过敏史人数" :value 3 :trend :down :description "比昨日减少1人"}])
 
 (def default-db
   { ;; Root map for the entire default database state
@@ -14,4 +25,4 @@
    :is-logged-in false
    :login-error nil
    :session-check-pending? true
-   })
+   :overview-stats default-overview-stats})

--- a/src/cljs/hc/hospital/pages/overview.cljs
+++ b/src/cljs/hc/hospital/pages/overview.cljs
@@ -1,16 +1,29 @@
 (ns hc.hospital.pages.overview
   "纵览信息模块，展示统计概览与图表。"
   (:require
+   ["@ant-design/icons" :as icons]
    ["antd" :refer [Card DatePicker Row Col]]
    ["echarts" :as echarts]
    [reagent.core :as r]
-   [re-frame.core :as rf]))
+   [re-frame.core :as rf]
+   [hc.hospital.subs :as subs]))
 
 (defn ^:private init-chart [id option]
   (let [dom (.getElementById js/document id)
         inst (.init echarts dom)]
     (.setOption inst (clj->js option)))
   nil)
+
+(defn- trend-display [{:keys [trend description]}]
+  (case trend
+    :up [:span {:style {:color "#52c41a"}}
+         (r/as-element [:> icons/ArrowUpOutlined])
+         (str " " description)]
+    :down [:span {:style {:color "#f5222d"}}
+           (r/as-element [:> icons/ArrowDownOutlined])
+           (str " " description)]
+    :same [:span description]
+    [:span description]))
 
 (defn overview-content []
   (r/create-class
@@ -33,27 +46,33 @@
                                        :series [{:type "bar" :data [80]}]}))
     :reagent-render
     (fn []
-      [:div
-       [:> Card {:title "今日数据概览" :style {:marginBottom 16}}
-        [:> Row {:gutter 16}
-         [:> Col {:span 6}
-          [:div {:style {:textAlign "center"}}
-           [:div {:style {:fontSize 24 :color "#1890ff"}} "156"]
-           [:div "总就诊人数"]]]
-         [:> Col {:span 6}
-          [:div {:style {:textAlign "center"}}
-           [:div {:style {:fontSize 24 :color "#1890ff"}} "42"]
-           [:div "今日患者人数"]]]
-         [:> Col {:span 6}
-          [:div {:style {:textAlign "center"}}
-           [:div {:style {:fontSize 24 :color "#1890ff"}} "18"]
-           [:div "手术患者人数"]]]
-         [:> Col {:span 6}
-          [:div {:style {:textAlign "center"}}
-           [:div {:style {:fontSize 24 :color "#1890ff"}} "15"]
-           [:div "已签字人数"]]]]]
-       [:> Card {:title "数据来源分布"}
-        [:div {:id "patientSourceChart" :style {:height 300}}]
-        [:div {:id "asaChart" :style {:height 300}}]
-        [:div {:id "approvalRateChart" :style {:height 300}}]]])}))
+      (let [stats @(rf/subscribe [::subs/overview-stats])
+            row1 (take 4 stats)
+            row2 (drop 4 stats)]
+        [:div
+         [:> Card {:title "今日数据概览" :style {:marginBottom 16}}
+          [:<> 
+           [:> Row {:gutter 16}
+            (for [{:keys [label value] :as item} row1]
+              ^{:key label}
+              [:> Col {:span 6}
+               [:div {:style {:textAlign "center"}}
+                [:div {:style {:fontSize 24 :color "#1890ff"}} value]
+                [:div label]
+                [:div {:style {:marginTop 4}}
+                 (trend-display item)]]])]
+           (when (seq row2)
+             [:> Row {:gutter 16 :style {:marginTop 12}}
+              (for [{:keys [label value] :as item} row2]
+                ^{:key label}
+                [:> Col {:span 8}
+                 [:div {:style {:textAlign "center"}}
+                  [:div {:style {:fontSize 24 :color "#1890ff"}} value]
+                  [:div label]
+                  [:div {:style {:marginTop 4}}
+                   (trend-display item)]]])])]]
+         [:> Card {:title "数据来源分布"}
+          [:div {:id "patientSourceChart" :style {:height 300}}]
+          [:div {:id "asaChart" :style {:height 300}}]
+          [:div {:id "approvalRateChart" :style {:height 300}}]]]))})
 

--- a/src/cljs/hc/hospital/subs.cljs
+++ b/src/cljs/hc/hospital/subs.cljs
@@ -270,6 +270,11 @@
   (fn [db _]
     (get db :session-check-pending? true))) ; Default to true if not found, matches db.cljs
 
+;; 首页概览统计订阅
+(rf/reg-sub ::overview-stats
+  (fn [db _]
+    (get db :overview-stats [])))
+
 ;; --- 二维码扫描模态框订阅 ---
 ;; 订阅二维码扫描模态框的可见状态
 (rf/reg-sub ::qr-scan-modal-visible?


### PR DESCRIPTION
## Summary
- expand overview stats default values
- expose new `overview-stats` subscription
- render overview stats dynamically with up/down trend colors

## Testing
- `npx shadow-cljs compile app` *(fails: Network is unreachable)*
- `clj -M:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852bab444188327aa1bc36cf4d734ad