### PR TITLE
Update overview to card flex layout

### DIFF
--- a/src/cljs/hc/hospital/pages/overview.cljs
+++ b/src/cljs/hc/hospital/pages/overview.cljs
@@ -2,7 +2,7 @@
   "纵览信息模块，展示统计概览与图表。"
   (:require
    ["@ant-design/icons" :as icons]
-   ["antd" :refer [Card DatePicker Row Col]]
+   ["antd" :refer [Card]]
    ["echarts" :as echarts]
    [reagent.core :as r]
    [re-frame.core :as rf]
@@ -25,54 +25,97 @@
     :same [:span description]
     [:span description]))
 
+(defn- stat-card [{:keys [label value] :as item}]
+  [:> Card {:style {:flex "1 0 200px" :marginBottom 16}}
+   [:div {:style {:textAlign "center"}}
+    [:div {:style {:fontSize 24 :color "#1890ff"}} value]
+    [:div label]
+    [:div {:style {:marginTop 4}}
+     (trend-display item)]]])
+
+(defn- chart-card [id title]
+  [:> Card {:title title
+            :style {:flex "1 0 300px" :marginBottom 16}}
+   [:div {:id id :style {:height 300}}]])
+
 (defn overview-content []
   (r/create-class
    {:component-did-mount
     (fn []
-      (init-chart "patientSourceChart" {:title {:text "来源分布"}
-                                        :tooltip {}
-                                        :series [{:type "pie"
-                                                  :data [{:name "自助" :value 40}
-                                                         {:name "转诊" :value 60}]}]})
-      (init-chart "asaChart" {:title {:text "ASA分级"}
-                              :xAxis {:type "category"
-                                      :data ["I" "II" "III"]}
-                              :yAxis {:type "value"}
-                              :series [{:type "bar"
-                                        :data [20 30 10]}]})
-      (init-chart "approvalRateChart" {:title {:text "通过率"}
-                                       :xAxis {:type "category" :data ["今日"]}
-                                       :yAxis {:type "value"}
-                                       :series [{:type "bar" :data [80]}]}))
+      ;; 数据来源分布 - 每日门诊与住院患者
+      (init-chart "patientSourceChart"
+                  {:title {:text "数据来源分布"}
+                   :tooltip {:trigger "axis"}
+                   :legend {:data ["门诊" "住院"]}
+                   :xAxis {:type "category"
+                           :data ["周一" "周二" "周三" "周四" "周五" "周六" "周日"]}
+                   :yAxis {:type "value"}
+                   :series [{:name "门诊" :type "bar" :data [20 30 15 25 40 50 45]}
+                            {:name "住院" :type "bar" :data [10 20 25 30 35 40 30]}]})
+      ;; ASA 评级分布
+      (init-chart "asaChart"
+                  {:title {:text "ASA评级分布"}
+                   :tooltip {:trigger "item"}
+                   :series [{:type "pie"
+                             :radius "50%"
+                             :data [{:name "I级" :value 30}
+                                    {:name "II级" :value 50}
+                                    {:name "III级" :value 20}]
+                             :emphasis {:itemStyle {:shadowBlur 10
+                                                    :shadowOffsetX 0
+                                                    :shadowColor "rgba(0,0,0,0.5)"}}}]})
+      ;; 通过率
+      (init-chart "approvalRateChart"
+                  {:title {:text "通过率"}
+                   :tooltip {:trigger "item"}
+                   :series [{:type "pie"
+                             :radius ["40%" "70%"]
+                             :label {:show false}
+                             :emphasis {:label {:show true :fontSize 20 :fontWeight "bold"}}
+                             :labelLine {:show false}
+                             :data [{:name "通过" :value 80}
+                                    {:name "未通过" :value 20}]}]})
+      ;; 最近10天手术人数
+      (init-chart "surgeryCountChart"
+                  {:title {:text "最近10天手术人数"}
+                   :tooltip {:trigger "axis"}
+                   :xAxis {:type "category"
+                           :data ["1日" "2日" "3日" "4日" "5日" "6日" "7日" "8日" "9日" "10日"]}
+                   :yAxis {:type "value"}
+                   :series [{:type "line"
+                             :data [15 18 20 22 19 16 24 28 30 27]}]})
+      ;; 性别分布
+      (init-chart "genderChart"
+                  {:title {:text "性别分布"}
+                   :tooltip {:trigger "item"}
+                   :series [{:type "pie"
+                             :radius ["40%" "70%"]
+                             :data [{:name "男" :value 60}
+                                    {:name "女" :value 40}]}]})
+      ;; 年龄分布
+      (init-chart "ageChart"
+                  {:title {:text "年龄分布"}
+                   :tooltip {:trigger "axis"}
+                   :xAxis {:type "category" :data ["0-20" "21-40" "41-60" "61+"]}
+                   :yAxis {:type "value"}
+                   :series [{:type "bar" :data [5 20 30 15]}]}))
     :reagent-render
     (fn []
-      (let [stats @(rf/subscribe [::subs/overview-stats])
-            row1 (take 4 stats)
-            row2 (drop 4 stats)]
+      (let [stats @(rf/subscribe [::subs/overview-stats])]
         [:div
          [:> Card {:title "今日数据概览" :style {:marginBottom 16}}
-          [:<>
-           [:> Row {:gutter 16}
-            (for [{:keys [label value] :as item} row1]
-              ^{:key label}
-              [:> Col {:span 6}
-               [:div {:style {:textAlign "center"}}
-                [:div {:style {:fontSize 24 :color "#1890ff"}} value]
-                [:div label]
-                [:div {:style {:marginTop 4}}
-                 (trend-display item)]]])]
-           (when (seq row2)
-             [:> Row {:gutter 16 :style {:marginTop 12}}
-              (for [{:keys [label value] :as item} row2]
-                ^{:key label}
-                [:> Col {:span 8}
-                 [:div {:style {:textAlign "center"}}
-                  [:div {:style {:fontSize 24 :color "#1890ff"}} value]
-                  [:div label]
-                  [:div {:style {:marginTop 4}}
-                   (trend-display item)]]])])]]
-         [:> Card {:title "数据来源分布"}
-          [:div {:id "patientSourceChart" :style {:height 300}}]
-          [:div {:id "asaChart" :style {:height 300}}]
-          [:div {:id "approvalRateChart" :style {:height 300}}]]]))}))
+          [:div {:style {:display "flex" :flexWrap "wrap" :gap 16}}
+           (for [item stats]
+             ^{:key (:label item)}
+             [stat-card item])]]
+         [:> Card {:title "数据来源分布" :style {:marginBottom 16}}
+          [:div {:style {:display "flex" :flexWrap "wrap" :gap 16}}
+           [chart-card "patientSourceChart" "数据来源分布"]
+           [chart-card "asaChart" "ASA评级分布"]
+           [chart-card "approvalRateChart" "通过率"]]]
+         [:> Card {:title "手术数据分析"}
+          [:div {:style {:display "flex" :flexWrap "wrap" :gap 16}}
+           [chart-card "surgeryCountChart" "最近10天手术人数"]
+           [chart-card "genderChart" "性别分布"]
+           [chart-card "ageChart" "年龄分布"]]]]))}))
 


### PR DESCRIPTION
## Summary
- refactor Overview page stats section
- use flex layout with wrapping
- display each stat in its own card
- add data source and surgery analysis charts with sub-cards

## Testing
- `npx yarn@1 install`
- `npx shadow-cljs compile app` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6852bddd7ac48327a2ae8bdabcbcfb51