### PR TITLE
修复概览无数据时前端显示

### DIFF
--- a/src/cljs/hc/hospital/db.cljs
+++ b/src/cljs/hc/hospital/db.cljs
@@ -12,6 +12,14 @@
    {:label "高血压人数" :value 9 :trend :up :description "比昨日增加2人"}
    {:label "过敏史人数" :value 3 :trend :down :description "比昨日减少1人"}])
 
+(def empty-overview-stats
+  "没有任何记录时展示的默认统计数据"
+  (mapv (fn [item]
+          (assoc item :value 0
+                      :trend :same
+                      :description "无变化"))
+        default-overview-stats))
+
 (def default-db
   { ;; Root map for the entire default database state
    :anesthesia {}

--- a/src/cljs/hc/hospital/events.cljs
+++ b/src/cljs/hc/hospital/events.cljs
@@ -585,7 +585,7 @@
 
 (rf/reg-event-db ::set-overview-stats
   (fn [db [_ {:keys [stats]}]]
-    (assoc db :overview-stats stats)))
+    (assoc db :overview-stats (or stats app-db/empty-overview-stats))))
 
 (rf/reg-event-db ::fetch-overview-stats-failed
   (fn [db [_ error]]


### PR DESCRIPTION
## Summary
- 提供 `empty-overview-stats` 用于无记录时展示
- 当后端返回 `nil` 时使用默认值填充概览数据

## Testing
- `yarn install`
- `npx shadow-cljs compile app` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6853b9fa6d0c83278188dff2a7fc1706