### PR TITLE
实现护士签到登记页面

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -231,10 +231,11 @@
 | 纵览信息   | view   | 首页统计和图表           |
 | 麻醉管理   | view   | 患者评估与麻醉适应性决策 |
 | 问卷列表   | view   | 历史问卷记录查看         |
+| 签到登记   | view   | 护士登记患者到院信息     |
 | 系统管理   | view-users, create-user, edit-user, delete-user, view-roles, edit-role | 后台用户及角色管理 |
 
 管理员拥有全部权限；麻醉医生拥有“麻醉管理”“问卷列表”和“纵览信息”权限；护士拥有“纵览信息”
-和“问卷列表”权限。
+“问卷列表”和“签到登记”权限。
 
 前端登录后会根据医生的 `role` 字段调用 `/api/roles` 与 `/api/roles/:id/permissions`
 获取权限列表，并将结果存入 `current-role-permissions`。页面组件根据该列表决定是否呈现

--- a/resources/migrations/20250701000000-add-checkin-time-column.down.sql
+++ b/resources/migrations/20250701000000-add-checkin-time-column.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_patient_assessments_checkin;
+--;;
+ALTER TABLE patient_assessments DROP COLUMN checkin_time;

--- a/resources/migrations/20250701000000-add-checkin-time-column.up.sql
+++ b/resources/migrations/20250701000000-add-checkin-time-column.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE patient_assessments ADD COLUMN checkin_time TEXT;
+--;;
+CREATE INDEX IF NOT EXISTS idx_patient_assessments_checkin ON patient_assessments(checkin_time);

--- a/resources/migrations/20250701010000-add-checkin-permission.down.sql
+++ b/resources/migrations/20250701010000-add-checkin-permission.down.sql
@@ -1,0 +1,3 @@
+DELETE FROM role_permissions WHERE permission_id IN (SELECT id FROM permissions WHERE module='签到登记' AND action='view');
+--;;
+DELETE FROM permissions WHERE module='签到登记' AND action='view';

--- a/resources/migrations/20250701010000-add-checkin-permission.up.sql
+++ b/resources/migrations/20250701010000-add-checkin-permission.up.sql
@@ -1,0 +1,8 @@
+INSERT INTO permissions (module, action)
+SELECT '签到登记', 'view'
+WHERE NOT EXISTS (SELECT 1 FROM permissions WHERE module='签到登记' AND action='view');
+--;;
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id FROM roles r, permissions p
+WHERE r.name='护士' AND p.module='签到登记' AND p.action='view'
+  AND NOT EXISTS (SELECT 1 FROM role_permissions rp WHERE rp.role_id=r.id AND rp.permission_id=p.id);

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -4,8 +4,8 @@
 -- :name insert-patient-assessment! :! :n
 -- :doc 插入一个新的患者评估记录
 INSERT INTO patient_assessments
-(patient_id, assessment_data, patient_name, assessment_status, patient_name_pinyin, patient_name_initial, doctor_signature_b64, created_at, updated_at) -- 中文注释：新增姓名和状态字段
-VALUES (:patient_id, :assessment_data, :patient_name, :assessment_status, :patient_name_pinyin, :patient_name_initial, :doctor_signature_b64, datetime('now'), datetime('now')); -- 中文注释：添加 doctor_signature_b64 参数
+(patient_id, assessment_data, patient_name, assessment_status, patient_name_pinyin, patient_name_initial, doctor_signature_b64, checkin_time, created_at, updated_at) -- 中文注释：新增姓名、状态及签到时间字段
+VALUES (:patient_id, :assessment_data, :patient_name, :assessment_status, :patient_name_pinyin, :patient_name_initial, :doctor_signature_b64, :checkin_time, datetime('now'), datetime('now')); -- 中文注释：添加 doctor_signature_b64 与 checkin_time 参数
 
 -- 更新患者评估
 -- :name update-patient-assessment! :! :n
@@ -17,6 +17,7 @@ SET assessment_data = :assessment_data,
     patient_name_pinyin = :patient_name_pinyin,
     patient_name_initial = :patient_name_initial,
     doctor_signature_b64 = :doctor_signature_b64, -- 中文注释：添加 doctor_signature_b64 更新
+    checkin_time = :checkin_time,
     updated_at = datetime('now')
 WHERE patient_id = :patient_id;
 

--- a/src/cljc/hc/hospital/specs/assessment_complete_cn_spec.cljc
+++ b/src/cljc/hc/hospital/specs/assessment_complete_cn_spec.cljc
@@ -778,6 +778,7 @@
       [:评估状态 {:optional true} [:enum "待评估" "已批准" "已驳回" "已暂缓" "评估中"]]
       [:医生姓名 {:optional true} OptionalString]
       [:评估备注 {:optional true} OptionalString]
+      [:签到时间 {:optional true} Optional日期时间字符串]
       [:身高cm {:optional true} OptionalNumber]          ; 医生补充
       [:体重kg {:optional true} OptionalNumber]          ; 医生补充
       [:精神状态 {:optional true} OptionalString]        ; 医生补充

--- a/src/cljs/hc/hospital/events.cljs
+++ b/src/cljs/hc/hospital/events.cljs
@@ -15,7 +15,7 @@
   "系统初始化时使用的评估模板。"
   {:基本信息 {:门诊号 nil, :姓名 nil, :身份证号 nil, :手机号 nil, :性别 nil,
             :年龄 nil, :院区 nil, :患者提交时间 nil, :评估更新时间 nil,
-            :评估状态 "待评估", :医生姓名 nil, :评估备注 nil, :身高cm nil,
+            :评估状态 "待评估", :医生姓名 nil, :评估备注 nil, :签到时间 nil, :身高cm nil,
             :体重kg nil, :精神状态 nil, :活动能力 nil, :血压mmHg nil,
             :脉搏次每分 nil, :呼吸次每分 nil, :体温摄氏度 nil, :SpO2百分比 nil,
             :术前诊断 nil, :拟施手术 nil}

--- a/src/cljs/hc/hospital/pages/anesthesia.cljs
+++ b/src/cljs/hc/hospital/pages/anesthesia.cljs
@@ -134,7 +134,7 @@
    [patient-list-filters]
    [patient-list]])
 
-(defn- patient-info-card "显示患者基本信息" [props]
+(defn patient-info-card "显示患者基本信息" [props]
   (let [{:keys [report-form-instance-fn]} props
         basic-info @(rf/subscribe [::subs/canonical-basic-info])
         patient-id (get basic-info :门诊号) ; Used for keying the form and useEffect dep
@@ -179,7 +179,7 @@
                      :onChange #(rf/dispatch [::events/update-canonical-assessment-field [:基本信息 :拟施手术] (-> % .-target .-value)])}]]]]
        [:> Empty {:description "请先选择患者或患者无基本信息"}])]))
 
-(defn- general-condition-card "显示一般情况" []
+(defn general-condition-card "显示一般情况" []
   (let [basic-info-data @(rf/subscribe [::subs/canonical-basic-info]) ; Changed subscription
         patient-id @(rf/subscribe [::subs/canonical-patient-outpatient-number])
         mental-status-options [{:value "清醒" :label "清醒"}

--- a/src/cljs/hc/hospital/pages/anesthesia_home.cljs
+++ b/src/cljs/hc/hospital/pages/anesthesia_home.cljs
@@ -7,6 +7,7 @@
    [hc.hospital.events :as events]
    [hc.hospital.components.qr-scan-modal :refer [qr-scan-modal]]
    [hc.hospital.pages.anesthesia :refer [anesthesia-content]]
+   [hc.hospital.pages.checkin :refer [checkin-content]]
    [hc.hospital.pages.overview :refer [overview-content]]
    [hc.hospital.pages.comps :refer [custom-sider-trigger]]
    [hc.hospital.pages.settings :refer [system-settings-content]]
@@ -20,8 +21,9 @@
 (def menu-definitions
   [{:key "1" :icon (r/as-element [:> icons/DashboardOutlined]) :label "纵览信息"  :module "纵览信息"  :tab "overview"}
    {:key "2" :icon (r/as-element [:> icons/ProfileOutlined])   :label "麻醉管理"  :module "麻醉管理"  :tab "patients"}
-   {:key "3" :icon (r/as-element [:> icons/FileAddOutlined])   :label "问卷列表"  :module "问卷列表"  :tab "assessment"}
-   {:key "4" :icon (r/as-element [:> icons/SettingOutlined])   :label "系统管理"  :module "系统管理"  :tab "settings"}])
+  {:key "3" :icon (r/as-element [:> icons/FileAddOutlined])   :label "问卷列表"  :module "问卷列表"  :tab "assessment"}
+  {:key "5" :icon (r/as-element [:> icons/CheckCircleOutlined]) :label "签到登记" :module "签到登记" :tab "checkin"}
+  {:key "4" :icon (r/as-element [:> icons/SettingOutlined])   :label "系统管理"  :module "系统管理"  :tab "settings"}])
 
 (def key-by-tab (into {} (map (juxt :tab :key) menu-definitions)))
 (def tab-by-key (into {} (map (juxt :key :tab) menu-definitions)))
@@ -105,6 +107,9 @@
         "assessment" (if (contains? allowed "问卷列表")
                         [questionnaire-list-content]
                         [:div "无权限"])
+        "checkin" (if (contains? allowed "签到登记")
+                     [checkin-content]
+                     [:div "无权限"])
         "settings" (if (contains? allowed "系统管理")
                       [:f> system-settings-content]
                       [:div "无权限"])

--- a/src/cljs/hc/hospital/pages/checkin.cljs
+++ b/src/cljs/hc/hospital/pages/checkin.cljs
@@ -1,0 +1,57 @@
+(ns hc.hospital.pages.checkin
+  (:require ["antd" :refer [Layout Card Button Empty]]
+            ["@ant-design/icons" :refer [SaveOutlined]]
+            [re-frame.core :as rf]
+            [reagent.core :as r]
+            [hc.hospital.subs :as subs]
+            [hc.hospital.events :as events]
+            [hc.hospital.pages.anesthesia :as anesthesia]))
+
+(defn patient-list []
+  (let [patients @(rf/subscribe [::subs/unchecked-patients])
+        current-id @(rf/subscribe [::subs/current-patient-id])]
+    [:div {:style {:height "100%" :overflowY "auto"}}
+     (if (seq patients)
+       (for [p patients]
+         ^{:key (:key p)}
+         [:div {:style {:padding "10px 12px"
+                        :borderBottom "1px solid #f0f0f0"
+                        :background (when (= (:key p) current-id) "#e6f7ff")
+                        :cursor "pointer"}
+                :onClick #(rf/dispatch [::events/select-patient (:key p)])}
+          (:name p)])
+       [:> Empty {:description "暂无待签到患者"}])]))
+
+(defn patient-list-panel []
+  [:div {:style {:padding "16px"}}
+   [patient-list]])
+
+(defn save-button []
+  [:> Layout.Footer {:style {:padding "10px 0"
+                             :background "white"
+                             :borderTop "1px solid #f0f0f0"
+                             :textAlign "center"}}
+   [:> Button {:type "primary"
+               :icon (r/as-element [:> SaveOutlined])
+               :onClick (fn []
+                          (rf/dispatch [::events/update-canonical-assessment-field [:基本信息 :签到时间] (.toISOString (js/Date.))])
+                          (rf/dispatch [::events/save-final-assessment-later]))}
+    "确认签到"]])
+
+(defn assessment []
+  (let [current-id @(rf/subscribe [::subs/current-patient-id])]
+    (if current-id
+      [:> Layout {:style {:display "flex" :flexDirection "column" :height "calc(100vh - 64px)"}}
+       [:> Layout.Content {:style {:padding "5px 12px" :overflowY "auto" :flexGrow 1 :background "#f0f2f5"}}
+        [:f> anesthesia/patient-info-card]
+        [anesthesia/general-condition-card]]
+       [save-button]]
+      [:div {:style {:display "flex" :justifyContent "center" :alignItems "center" :height "100%"}}
+       [:> Empty {:description "请选择患者"}]])))
+
+(defn checkin-content []
+  [:> Layout.Content {:style {:margin 0 :minHeight 280 :overflow "hidden" :display "flex"}}
+   [:> Card {:style {:width "400px" :minWidth "350px" :height "calc(100vh - 64px)" :borderRight "1px solid #f0f0f0" :padding "0"}}
+    [patient-list-panel]]
+   [:div {:style {:flexGrow 1 :background "#f0f2f5" :overflow "hidden" :display "flex" :flexDirection "column"}}
+    [assessment]])]

--- a/src/cljs/hc/hospital/pages/role_settings.cljs
+++ b/src/cljs/hc/hospital/pages/role_settings.cljs
@@ -8,9 +8,10 @@
 
 (def tree-data
   [{:title "纵览信息" :key 1 :children [{:title "查看" :key 101}]}
-   {:title "麻醉管理" :key 2 :children [{:title "查看" :key 102}]}
-   {:title "问卷列表" :key 3 :children [{:title "查看" :key 103}]}
-   {:title "系统管理" :key 4
+  {:title "麻醉管理" :key 2 :children [{:title "查看" :key 102}]}
+  {:title "问卷列表" :key 3 :children [{:title "查看" :key 103}]}
+  {:title "签到登记" :key 5 :children [{:title "查看" :key 110}]}
+  {:title "系统管理" :key 4
     :children [{:title "查看用户" :key 104}
                {:title "新增用户" :key 105}
                {:title "编辑用户" :key 106}

--- a/src/cljs/hc/hospital/router.cljs
+++ b/src/cljs/hc/hospital/router.cljs
@@ -9,8 +9,9 @@
   "路由表，定义页面标签与路径的映射。"
   [["/" {:name :overview}]
    ["/patients" {:name :patients}]
-   ["/assessment" {:name :assessment}]
-   ["/settings" {:name :settings}]])
+  ["/assessment" {:name :assessment}]
+  ["/checkin" {:name :checkin}]
+  ["/settings" {:name :settings}]])
 
 (def router
   (rf/router routes))
@@ -30,8 +31,9 @@
 (def tab->route
   {"overview" :overview
    "patients" :patients
-   "assessment" :assessment
-   "settings" :settings})
+  "assessment" :assessment
+  "checkin" :checkin
+  "settings" :settings})
 
 (defn navigate!
   "根据标签名导航到相应路径。"

--- a/src/cljs/hc/hospital/subs.cljs
+++ b/src/cljs/hc/hospital/subs.cljs
@@ -82,6 +82,13 @@
 
           true identity)))))
 
+(rf/reg-sub ::unchecked-patients
+  :<- [::all-patient-assessments]
+  (fn [assessments _]
+    (->> assessments
+         (filterv #(nil? (:checkin_time %)))
+         vec)))
+
 (rf/reg-sub ::doctor-form-physical-examination
   (fn [db _]
     (get-in db [:anesthesia :assessment :form-data])))

--- a/test/clj/hc/hospital/db/patient_assessment_test.clj
+++ b/test/clj/hc/hospital/db/patient_assessment_test.clj
@@ -20,7 +20,8 @@
         initial-assessment-data {:form "initial-form-data"}
         initial-signature "data:image/png;base64,INITIAL_SIGNATURE_DATA"
         updated-signature "data:image/png;base64,UPDATED_SIGNATURE_DATA"
-        assessment-data-json (json/generate-string initial-assessment-data)]
+        assessment-data-json (json/generate-string initial-assessment-data)
+        checkin-time "2099-01-01T00:00:00Z"]
 
     (testing "插入患者评估 (带签名)"
       (let [insert-result (query-fn :insert-patient-assessment!
@@ -30,12 +31,14 @@
                                      :assessment_status "待评估"
                                      :patient_name_pinyin "ceshipinyin"
                                      :patient_name_initial "cspy"
-                                     :doctor_signature_b64 initial-signature})
+                                     :doctor_signature_b64 initial-signature
+                                     :checkin_time checkin-time})
             retrieved (query-fn :get-patient-assessment-by-id {:patient_id patient-id})]
         (is (= 1 insert-result) "插入应返回影响的行数为1")
         (is (some? retrieved) "应能检索到插入的评估")
         (is (= assessment-data-json (:assessment_data retrieved)) "评估数据应匹配")
-        (is (= initial-signature (:doctor_signature_b64 retrieved)) "医生签名应匹配")))
+        (is (= initial-signature (:doctor_signature_b64 retrieved)) "医生签名应匹配")
+        (is (= checkin-time (:checkin_time retrieved)) "签到时间应匹配")))
 
     (testing "更新患者评估 (修改签名)"
       (let [updated-assessment-data {:form "updated-form-data"}

--- a/test/clj/hc/hospital/db/role_test.clj
+++ b/test/clj/hc/hospital/db/role_test.clj
@@ -21,4 +21,6 @@
     (is (some? nurse) "护士角色应存在")
     (let [perms (role-db/get-permissions-by-role query-fn (:id nurse))]
       (is (not-any? #(= "麻醉管理" (:module %)) perms)
-          "护士不应拥有麻醉管理权限"))))
+          "护士不应拥有麻醉管理权限")
+      (is (some #(= "签到登记" (:module %)) perms)
+          "护士应拥有签到登记权限"))))


### PR DESCRIPTION
## Summary
- 新增`checkin_time`字段及权限迁移
- 扩展评估数据Spec和默认值
- 新增护士`签到登记`权限并更新角色设置
- 增加前端路由及页面实现
- 更新相关测试

## Testing
- `clojure -M:test` *(failed: Could not download dependencies)*
- `yarn install`
- `npx shadow-cljs compile app` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6854de2837a08327a5db25ead1812ffe