### PR TITLE
实现护士签到登记页面

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -231,10 +231,11 @@
 | 纵览信息   | view   | 首页统计和图表           |
 | 麻醉管理   | view   | 患者评估与麻醉适应性决策 |
 | 问卷列表   | view   | 历史问卷记录查看         |
+| 签到登记   | view   | 护士登记患者到院信息     |
 | 系统管理   | view-users, create-user, edit-user, delete-user, view-roles, edit-role | 后台用户及角色管理 |
 
 管理员拥有全部权限；麻醉医生拥有“麻醉管理”“问卷列表”和“纵览信息”权限；护士拥有“纵览信息”
-和“问卷列表”权限。
+“问卷列表”和“签到登记”权限。
 
 前端登录后会根据医生的 `role` 字段调用 `/api/roles` 与 `/api/roles/:id/permissions`
 获取权限列表，并将结果存入 `current-role-permissions`。页面组件根据该列表决定是否呈现

--- a/resources/migrations/20250701000000-add-checkin-time-column.down.sql
+++ b/resources/migrations/20250701000000-add-checkin-time-column.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_patient_assessments_checkin;
+--;;
+ALTER TABLE patient_assessments DROP COLUMN checkin_time;

--- a/resources/migrations/20250701000000-add-checkin-time-column.up.sql
+++ b/resources/migrations/20250701000000-add-checkin-time-column.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE patient_assessments ADD COLUMN checkin_time TEXT;
+--;;
+CREATE INDEX IF NOT EXISTS idx_patient_assessments_checkin ON patient_assessments(checkin_time);

--- a/resources/migrations/20250701010000-add-checkin-permission.down.sql
+++ b/resources/migrations/20250701010000-add-checkin-permission.down.sql
@@ -1,0 +1,3 @@
+DELETE FROM role_permissions WHERE permission_id IN (SELECT id FROM permissions WHERE module='签到登记' AND action='view');
+--;;
+DELETE FROM permissions WHERE module='签到登记' AND action='view';

--- a/resources/migrations/20250701010000-add-checkin-permission.up.sql
+++ b/resources/migrations/20250701010000-add-checkin-permission.up.sql
@@ -1,0 +1,8 @@
+INSERT INTO permissions (module, action)
+SELECT '签到登记', 'view'
+WHERE NOT EXISTS (SELECT 1 FROM permissions WHERE module='签到登记' AND action='view');
+--;;
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id FROM roles r, permissions p
+WHERE r.name='护士' AND p.module='签到登记' AND p.action='view'
+  AND NOT EXISTS (SELECT 1 FROM role_permissions rp WHERE rp.role_id=r.id AND rp.permission_id=p.id);

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -4,8 +4,8 @@
 -- :name insert-patient-assessment! :! :n
 -- :doc 插入一个新的患者评估记录
 INSERT INTO patient_assessments
-(patient_id, assessment_data, patient_name, assessment_status, patient_name_pinyin, patient_name_initial, doctor_signature_b64, created_at, updated_at) -- 中文注释：新增姓名和状态字段
-VALUES (:patient_id, :assessment_data, :patient_name, :assessment_status, :patient_name_pinyin, :patient_name_initial, :doctor_signature_b64, datetime('now'), datetime('now')); -- 中文注释：添加 doctor_signature_b64 参数
+(patient_id, assessment_data, patient_name, assessment_status, patient_name_pinyin, patient_name_initial, doctor_signature_b64, checkin_time, created_at, updated_at) -- 中文注释：新增姓名、状态及签到时间字段
+VALUES (:patient_id, :assessment_data, :patient_name, :assessment_status, :patient_name_pinyin, :patient_name_initial, :doctor_signature_b64, :checkin_time, datetime('now'), datetime('now')); -- 中文注释：添加 doctor_signature_b64 与 checkin_time 参数
 
 -- 更新患者评估
 -- :name update-patient-assessment! :! :n
@@ -17,6 +17,7 @@ SET assessment_data = :assessment_data,
     patient_name_pinyin = :patient_name_pinyin,
     patient_name_initial = :patient_name_initial,
     doctor_signature_b64 = :doctor_signature_b64, -- 中文注释：添加 doctor_signature_b64 更新
+    checkin_time = :checkin_time,
     updated_at = datetime('now')
 WHERE patient_id = :patient_id;
 

--- a/src/cljc/hc/hospital/specs/assessment_complete_cn_spec.cljc
+++ b/src/cljc/hc/hospital/specs/assessment_complete_cn_spec.cljc
@@ -778,6 +778,7 @@
       [:评估状态 {:optional true} [:enum "待评估" "已批准" "已驳回" "已暂缓" "评估中"]]
       [:医生姓名 {:optional true} OptionalString]
       [:评估备注 {:optional true} OptionalString]
+      [:签到时间 {:optional true} Optional日期时间字符串]
       [:身高cm {:optional true} OptionalNumber]          ; 医生补充
       [:体重kg {:optional true} OptionalNumber]          ; 医生补充
       [:精神状态 {:optional true} OptionalString]        ; 医生补充

--- a/src/cljs/hc/hospital/components/patient_list.cljs
+++ b/src/cljs/hc/hospital/components/patient_list.cljs
@@ -1,0 +1,100 @@
+(ns hc.hospital.components.patient-list
+  (:require ["@ant-design/icons" :as icons :refer [SyncOutlined QrcodeOutlined UserOutlined]]
+            ["antd" :refer [Button DatePicker Input Select Space Empty Tag]]
+            [re-frame.core :as rf]
+            [reagent.core :as r]
+            [hc.hospital.subs :as subs]
+            [hc.hospital.events :as events]))
+
+(defn patient-list-filters []
+  (let [date-range @(rf/subscribe [::subs/date-range])
+        status @(rf/subscribe [::subs/assessment-status-filter])
+        assessment-status-options [{:value "all" :label "全部状态"}
+                                   {:value "待评估" :label "待评估"}
+                                   {:value "评估中" :label "评估中"}
+                                   {:value "已批准" :label "已批准"}
+                                   {:value "已驳回" :label "已驳回"}
+                                   {:value "已暂缓" :label "已暂缓"}]
+        label-width "60px"]
+    [:div {:style {:padding "16px" :borderBottom "1px solid #f0f0f0"}}
+     [:> Space {:style {:marginBottom "16px"
+                        :width "100%"
+                        :display "flex"
+                        :justifyContent "space-between"
+                        :alignItems "center"}}
+      [:> Button {:type "primary"
+                  :icon (r/as-element [:> SyncOutlined])
+                  :onClick #(rf/dispatch [::events/sync-applications])
+                  :style {:display "flex" :alignItems "center"}}
+       "同步申请"]
+      [:> Button {:type "default"
+                  :icon (r/as-element [:> QrcodeOutlined])
+                  :on-click #(rf/dispatch [::events/open-qr-scan-modal])}
+       "扫码签到"]]
+     [:div {:style {:display "flex" :alignItems "center" :marginBottom "12px"}}
+      [:span {:style {:width label-width
+                      :textAlign "left"
+                      :color "#666"
+                      :marginRight "8px"}}
+       "申请日期:"]
+      [:> DatePicker.RangePicker
+       {:style {:flex "1"}
+        :value date-range
+        :onChange #(rf/dispatch [::events/set-date-range %])}]]
+     [:div {:style {:display "flex" :alignItems "center" :marginBottom "12px"}}
+      [:span {:style {:width label-width
+                      :textAlign "left"
+                      :color "#666"
+                      :marginRight "8px"}}
+       "状态:"]
+      [:> Select {:style {:flex "1"}
+                  :placeholder "评估状态: 请选择"
+                  :options assessment-status-options
+                  :value status
+                  :onChange #(rf/dispatch [::events/set-assessment-status-filter %])}]]
+     [:div {:style {:display "flex" :alignItems "center"}}
+      [:span {:style {:width label-width
+                      :textAlign "left"
+                      :color "#666"
+                      :marginRight "8px"}}
+       "患者:"]
+      [:> Input.Search {:style {:flex "1"}
+                        :placeholder "请输入患者姓名/门诊号"
+                        :allowClear true
+                        :onSearch #(rf/dispatch [::events/search-patients %])}]]]))
+
+(defn patient-list [patients-sub]
+  (let [patients @(rf/subscribe patients-sub)
+        current-patient-id @(rf/subscribe [::subs/current-patient-id])]
+    [:div {:style {:height "100%" :overflowY "auto"}}
+     (if (seq patients)
+       (for [item patients]
+         ^{:key (:key item)}
+         [:div {:style {:padding "10px 12px"
+                        :borderBottom "1px solid #f0f0f0"
+                        :display "flex"
+                        :justifyContent "space-between"
+                        :alignItems "center"
+                        :background (when (= (:key item) current-patient-id) "#e6f7ff")
+                        :cursor "pointer"}
+                :onClick #(rf/dispatch [::events/select-patient (:key item)])}
+          [:div {:style {:display "flex" :alignItems "center"}}
+           [:> UserOutlined {:style {:marginRight "8px" :fontSize "16px"}}]
+           [:div
+            [:div {:style {:fontWeight "500"}} (:name item)]
+            [:div {:style {:fontSize "12px" :color "gray"}}
+             (str (:gender item) " " (:age item) " " (:anesthesia-type item))]]]
+          [:div {:style {:textAlign "right"}}
+           [:div {:style {:fontSize "12px" :color "gray" :marginBottom "4px"}} (:date item)]
+           [:> Tag {:color (case (:status item)
+                             "待评估" "orange"
+                             "已批准" "green"
+                             "已暂缓" "blue"
+                             "已驳回" "red"
+                             "default")} (:status item)]]])
+       [:> Empty {:description "暂无患者数据" :style {:marginTop "40px"}}])]))
+
+(defn patient-list-panel [{:keys [patients-sub]}]
+  [:<>
+   [patient-list-filters]
+   [patient-list patients-sub]])

--- a/src/cljs/hc/hospital/db.cljs
+++ b/src/cljs/hc/hospital/db.cljs
@@ -26,6 +26,7 @@
    ;; 用户管理相关状态
    :users []
    :roles []
+   :permissions []
    :user-modal-visible? false
    :editing-user nil
    :role-modal-visible? false

--- a/src/cljs/hc/hospital/events.cljs
+++ b/src/cljs/hc/hospital/events.cljs
@@ -15,7 +15,7 @@
   "系统初始化时使用的评估模板。"
   {:基本信息 {:门诊号 nil, :姓名 nil, :身份证号 nil, :手机号 nil, :性别 nil,
             :年龄 nil, :院区 nil, :患者提交时间 nil, :评估更新时间 nil,
-            :评估状态 "待评估", :医生姓名 nil, :评估备注 nil, :身高cm nil,
+            :评估状态 "待评估", :医生姓名 nil, :评估备注 nil, :签到时间 nil, :身高cm nil,
             :体重kg nil, :精神状态 nil, :活动能力 nil, :血压mmHg nil,
             :脉搏次每分 nil, :呼吸次每分 nil, :体温摄氏度 nil, :SpO2百分比 nil,
             :术前诊断 nil, :拟施手术 nil}
@@ -367,7 +367,8 @@
 
 (rf/reg-event-fx ::initialize-users
   (fn [_ _]
-    {:dispatch [::fetch-users]}))
+    {:dispatch-n [[::fetch-users]
+                  [::fetch-roles]]}))
 
 (rf/reg-event-fx ::fetch-users
   (fn [_ _]
@@ -473,7 +474,8 @@
 ;; ---- 角色管理事件 ----
 (rf/reg-event-fx ::initialize-roles
   (fn [_ _]
-    {:dispatch [::fetch-roles]}))
+    {:dispatch-n [[::fetch-roles]
+                  [::fetch-permissions]]}))
 
 (rf/reg-event-fx ::fetch-roles
   (fn [_ _]
@@ -485,6 +487,17 @@
 (rf/reg-event-db ::set-roles
   (fn [db [_ {:keys [roles]}]]
     (assoc db :roles roles)))
+
+(rf/reg-event-fx ::fetch-permissions
+  (fn [_ _]
+    {:http-xhrio {:method :get
+                  :uri "/api/permissions"
+                  :response-format (ajax/json-response-format {:keywords? true})
+                  :on-success [::set-permissions]}}))
+
+(rf/reg-event-db ::set-permissions
+  (fn [db [_ {:keys [permissions]}]]
+    (assoc db :permissions permissions)))
 
 (rf/reg-event-db ::open-role-modal
   (fn [db [_ role]]

--- a/src/cljs/hc/hospital/pages/anesthesia_home.cljs
+++ b/src/cljs/hc/hospital/pages/anesthesia_home.cljs
@@ -7,6 +7,7 @@
    [hc.hospital.events :as events]
    [hc.hospital.components.qr-scan-modal :refer [qr-scan-modal]]
    [hc.hospital.pages.anesthesia :refer [anesthesia-content]]
+   [hc.hospital.pages.checkin :refer [checkin-content]]
    [hc.hospital.pages.overview :refer [overview-content]]
    [hc.hospital.pages.comps :refer [custom-sider-trigger]]
    [hc.hospital.pages.settings :refer [system-settings-content]]
@@ -20,8 +21,9 @@
 (def menu-definitions
   [{:key "1" :icon (r/as-element [:> icons/DashboardOutlined]) :label "纵览信息"  :module "纵览信息"  :tab "overview"}
    {:key "2" :icon (r/as-element [:> icons/ProfileOutlined])   :label "麻醉管理"  :module "麻醉管理"  :tab "patients"}
-   {:key "3" :icon (r/as-element [:> icons/FileAddOutlined])   :label "问卷列表"  :module "问卷列表"  :tab "assessment"}
-   {:key "4" :icon (r/as-element [:> icons/SettingOutlined])   :label "系统管理"  :module "系统管理"  :tab "settings"}])
+  {:key "3" :icon (r/as-element [:> icons/FileAddOutlined])   :label "问卷列表"  :module "问卷列表"  :tab "assessment"}
+  {:key "5" :icon (r/as-element [:> icons/CheckCircleOutlined]) :label "签到登记" :module "签到登记" :tab "checkin"}
+  {:key "4" :icon (r/as-element [:> icons/SettingOutlined])   :label "系统管理"  :module "系统管理"  :tab "settings"}])
 
 (def key-by-tab (into {} (map (juxt :tab :key) menu-definitions)))
 (def tab-by-key (into {} (map (juxt :key :tab) menu-definitions)))
@@ -105,6 +107,9 @@
         "assessment" (if (contains? allowed "问卷列表")
                         [questionnaire-list-content]
                         [:div "无权限"])
+        "checkin" (if (contains? allowed "签到登记")
+                     [:f> checkin-content]
+                     [:div "无权限"])
         "settings" (if (contains? allowed "系统管理")
                       [:f> system-settings-content]
                       [:div "无权限"])

--- a/src/cljs/hc/hospital/pages/checkin.cljs
+++ b/src/cljs/hc/hospital/pages/checkin.cljs
@@ -1,0 +1,67 @@
+(ns hc.hospital.pages.checkin
+  (:require ["antd" :refer [Layout Card Button Empty]]
+            ["@ant-design/icons" :refer [SaveOutlined]]
+            ["react" :as React]
+            [re-frame.core :as rf]
+            [reagent.core :as r]
+            [hc.hospital.subs :as subs]
+            [hc.hospital.events :as events]
+            [hc.hospital.pages.anesthesia :as anesthesia]
+            [hc.hospital.components.patient-list :refer [patient-list-panel]]))
+
+
+(defn save-button []
+  [:> Layout.Footer {:style {:padding "10px 0"
+                             :background "white"
+                             :borderTop "1px solid #f0f0f0"
+                             :textAlign "center"}}
+  [:> Button {:type "primary"
+               :icon (r/as-element [:> SaveOutlined])
+               :onClick (fn []
+                          (rf/dispatch [::events/update-canonical-assessment-field [:基本信息 :签到时间] (.toISOString (js/Date.))])
+                          (rf/dispatch [::events/update-canonical-assessment-field [:基本信息 :评估状态] "评估中"]) ; 护士签到后状态变更
+                          (rf/dispatch [::events/save-final-assessment-later]))}
+    "确认签到"]])
+
+(defn- checkin-header [patient-name patient-status]
+  [:> Card {:style {:marginBottom "12px"}}
+   [:div {:style {:display "flex" :justifyContent "space-between" :alignItems "center"}}
+    [:h3 {:style {:fontSize "16px" :fontWeight "500"}} patient-name]
+    (when (= patient-status "已批准")
+      [:> Button {:type "primary"
+                  :danger true
+                  :on-click #(rf/dispatch [::events/reject-patient])}
+       "退回"])
+    (when (not= patient-status "已批准")
+      [:> Button {:type "primary"
+                  :on-click #(rf/dispatch [::events/approve-patient])}
+       "批准"])]])
+
+(defn assessment []
+  (let [current-id @(rf/subscribe [::subs/current-patient-id])
+        basic-info @(rf/subscribe [::subs/canonical-basic-info])
+        patient-name (get basic-info :姓名 "未知患者")
+        patient-status (get basic-info :评估状态 "待评估")
+        editable? (not= patient-status "已批准")] 
+    (if current-id
+      [:> Layout {:style {:display "flex" :flexDirection "column" :height "calc(100vh - 64px)"}}
+       [:> Layout.Content {:style {:padding "5px 12px" :overflowY "auto" :flexGrow 1 :background "#f0f2f5"}}
+        [checkin-header patient-name patient-status]
+        [:f> anesthesia/patient-info-card {:include-surgery-fields? false
+                                           :editable? editable?}]
+        [anesthesia/general-condition-card {:editable? editable?}]]
+       [save-button]]
+      [:div {:style {:display "flex" :justifyContent "center" :alignItems "center" :height "100%"}}
+       [:> Empty {:description "请选择患者"}]])))
+
+(defn checkin-content []
+  (React/useEffect
+   (fn []
+     (rf/dispatch [::events/set-assessment-status-filter "待评估"])
+     js/undefined)
+   #js [])
+  [:> Layout.Content {:style {:margin 0 :minHeight 280 :overflow "hidden" :display "flex"}}
+   [:> Card {:style {:width "400px" :minWidth "350px" :height "calc(100vh - 64px)" :borderRight "1px solid #f0f0f0" :padding "0"}}
+    [patient-list-panel {:patients-sub [::subs/unchecked-patients]}]]
+   [:div {:style {:flexGrow 1 :background "#f0f2f5" :overflow "hidden" :display "flex" :flexDirection "column"}}
+    [assessment]]])

--- a/src/cljs/hc/hospital/pages/role_settings.cljs
+++ b/src/cljs/hc/hospital/pages/role_settings.cljs
@@ -6,21 +6,34 @@
             [re-frame.core :as rf]
             [reagent.core :as r]))
 
-(def tree-data
-  [{:title "纵览信息" :key 1 :children [{:title "查看" :key 101}]}
-   {:title "麻醉管理" :key 2 :children [{:title "查看" :key 102}]}
-   {:title "问卷列表" :key 3 :children [{:title "查看" :key 103}]}
-   {:title "系统管理" :key 4
-    :children [{:title "查看用户" :key 104}
-               {:title "新增用户" :key 105}
-               {:title "编辑用户" :key 106}
-               {:title "删除用户" :key 107}
-               {:title "查看角色" :key 108}
-               {:title "角色编辑" :key 109}]}])
+(def action-labels
+  {"系统管理" {"view-users" "查看用户"
+             "create-user" "新增用户"
+             "edit-user" "编辑用户"
+             "delete-user" "删除用户"
+             "view-roles" "查看角色"
+             "edit-role" "角色编辑"}})
+
+(defn action->label [module action]
+  (get-in action-labels [module action] "查看"))
+
+(defn build-tree-data [permissions]
+  (->> permissions
+       (group-by :module)
+       (map (fn [[module perms]]
+              {:title module
+               :key module
+               :children (mapv (fn [{:keys [id action]}]
+                                  {:title (action->label module action)
+                                   :key id})
+                                perms)}))
+       vec))
 
 (defn role-modal []
   (let [visible? @(rf/subscribe [::subs/role-modal-visible?])
         role @(rf/subscribe [::subs/editing-role])
+        permissions @(rf/subscribe [::subs/permissions])
+        tree-data (build-tree-data permissions)
         ;; 本地勾选状态使用 React/useState 保存
         [checked set-checked] (React/useState [])]
     ;; 当打开弹窗或角色变更时获取权限

--- a/src/cljs/hc/hospital/router.cljs
+++ b/src/cljs/hc/hospital/router.cljs
@@ -9,8 +9,9 @@
   "路由表，定义页面标签与路径的映射。"
   [["/" {:name :overview}]
    ["/patients" {:name :patients}]
-   ["/assessment" {:name :assessment}]
-   ["/settings" {:name :settings}]])
+  ["/assessment" {:name :assessment}]
+  ["/checkin" {:name :checkin}]
+  ["/settings" {:name :settings}]])
 
 (def router
   (rf/router routes))
@@ -30,8 +31,9 @@
 (def tab->route
   {"overview" :overview
    "patients" :patients
-   "assessment" :assessment
-   "settings" :settings})
+  "assessment" :assessment
+  "checkin" :checkin
+  "settings" :settings})
 
 (defn navigate!
   "根据标签名导航到相应路径。"

--- a/src/cljs/hc/hospital/subs.cljs
+++ b/src/cljs/hc/hospital/subs.cljs
@@ -54,7 +54,8 @@
                  :anesthesia-type (or (:拟行麻醉方式 anesthesia-plan) "未知麻醉方式")
                  ;; Timestamps are now directly in basic_info according to canonical server structure
                  :date (format-date-str (:评估更新时间 basic-info)) ; Use 评估更新时间
-                 :status (or (:评估状态 basic-info) "待评估")}))] ; Use 评估状态
+                 :status (or (:评估状态 basic-info) "待评估")
+                 :checkin_time (:checkin_time assessment)}))] ; Use 评估状态
 
       (let [patients-from-api (if (seq api-assessments)
                                 (mapv patient-from-api-assessment api-assessments)
@@ -81,6 +82,13 @@
           (filterv (fn [p] (= (:status p) status-filter)))
 
           true identity)))))
+
+(rf/reg-sub ::unchecked-patients
+  :<- [::filtered-patients]
+  (fn [patients _]
+    (->> patients
+         (filterv #(nil? (:checkin_time %)))
+         vec)))
 
 (rf/reg-sub ::doctor-form-physical-examination
   (fn [db _]
@@ -241,6 +249,10 @@
 (rf/reg-sub ::roles
   (fn [db _]
     (get db :roles [])))
+
+(rf/reg-sub ::permissions
+  (fn [db _]
+    (get db :permissions [])))
 
 (rf/reg-sub ::user-modal-visible?
   (fn [db _]

--- a/test/clj/hc/hospital/db/patient_assessment_test.clj
+++ b/test/clj/hc/hospital/db/patient_assessment_test.clj
@@ -20,7 +20,8 @@
         initial-assessment-data {:form "initial-form-data"}
         initial-signature "data:image/png;base64,INITIAL_SIGNATURE_DATA"
         updated-signature "data:image/png;base64,UPDATED_SIGNATURE_DATA"
-        assessment-data-json (json/generate-string initial-assessment-data)]
+        assessment-data-json (json/generate-string initial-assessment-data)
+        checkin-time "2099-01-01T00:00:00Z"]
 
     (testing "插入患者评估 (带签名)"
       (let [insert-result (query-fn :insert-patient-assessment!
@@ -30,12 +31,14 @@
                                      :assessment_status "待评估"
                                      :patient_name_pinyin "ceshipinyin"
                                      :patient_name_initial "cspy"
-                                     :doctor_signature_b64 initial-signature})
+                                     :doctor_signature_b64 initial-signature
+                                     :checkin_time checkin-time})
             retrieved (query-fn :get-patient-assessment-by-id {:patient_id patient-id})]
         (is (= 1 insert-result) "插入应返回影响的行数为1")
         (is (some? retrieved) "应能检索到插入的评估")
         (is (= assessment-data-json (:assessment_data retrieved)) "评估数据应匹配")
-        (is (= initial-signature (:doctor_signature_b64 retrieved)) "医生签名应匹配")))
+        (is (= initial-signature (:doctor_signature_b64 retrieved)) "医生签名应匹配")
+        (is (= checkin-time (:checkin_time retrieved)) "签到时间应匹配")))
 
     (testing "更新患者评估 (修改签名)"
       (let [updated-assessment-data {:form "updated-form-data"}

--- a/test/clj/hc/hospital/db/role_test.clj
+++ b/test/clj/hc/hospital/db/role_test.clj
@@ -21,4 +21,6 @@
     (is (some? nurse) "护士角色应存在")
     (let [perms (role-db/get-permissions-by-role query-fn (:id nurse))]
       (is (not-any? #(= "麻醉管理" (:module %)) perms)
-          "护士不应拥有麻醉管理权限"))))
+          "护士不应拥有麻醉管理权限")
+      (is (some #(= "签到登记" (:module %)) perms)
+          "护士应拥有签到登记权限"))))


### PR DESCRIPTION
## Summary
- 调整签到登记页面为独立表头，不再显示知情同意书弹窗
- 签到登记时隐藏术前诊断、拟施手术字段，并在患者已批准后禁止编辑
- 一般情况卡片增加 `editable?` 参数，字段可根据权限禁用

## Testing
- `yarn install`
- `clj -M:test` *(failed: command not found)*
- `npx shadow-cljs compile app` *(failed to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6854de2837a08327a5db25ead1812ffe