### PR TITLE
更新 AGENTS.md，添加代理配置指南

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,28 @@ sudo ./linux-install.sh
 
 安装完成后运行 `clj -h` 验证是否安装成功。
 
+若需要通过代理下载依赖，请按照以下步骤配置：
+
+```bash
+mkdir -p ~/.m2
+cat > ~/.m2/settings.xml <<'EOF'
+<settings>
+  <proxies>
+    <proxy>
+      <id>codexProxy</id>
+      <active>true</active>
+      <protocol>http</protocol>
+      <host>proxy</host>
+      <port>8080</port>
+    </proxy>
+  </proxies>
+</settings>
+EOF
+
+export HTTP_PROXY=http://127.0.0.1:8080
+export HTTPS_PROXY=http://127.0.0.1:8080
+```
+
 
 ## 7. 权限与模块说明
 


### PR DESCRIPTION
## Summary
- 在 `AGENTS.md` 的環境初始化部分新增 Maven 與 Clojure 的代理配置說明，方便在受限環境中獲取依賴。

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68556cb73c808327b0f7dce8105dd004