### PR TITLE
Update AGENTS with proxy instructions for shadow-cljs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@
 - **测试:**
     - 所有新功能或 bug 修复都应伴随相应的测试。
     - 如果修改了前端代码，请在生成 PR 之前先运行 `yarn install` 确认依赖完整，再执行 `npx shadow-cljs compile app`，确保编译顺利完成。
+    - 如需通过代理访问依赖或构建产物，请在执行上述命令前设置 `HTTP_PROXY` 与 `HTTPS_PROXY` 环境变量为 `http://127.0.0.1:8080`，让 `shadow-cljs` 使用本地代理。
     - 运行后端测试的命令是 `clj -M:test`。
     - **注意:** `readme.org` 中已指出当前测试套件存在已知失败。在修复相关模块前，请不要尝试“修复”这些已知的测试失败。
     - **React Hook 组件调用:** 若组件内部使用 React 的 Hook（如 `useEffect`、`useState`），调用该组件时必须使用 `[:f> my-component]` 形式。
@@ -94,6 +95,8 @@ EOF
 export HTTP_PROXY=http://127.0.0.1:8080
 export HTTPS_PROXY=http://127.0.0.1:8080
 ```
+
+这些环境变量同样适用于 `yarn` 和 `shadow-cljs`，可确保在编译前端代码时也通过本地 8080 代理访问外部依赖。
 
 
 ## 7. 权限与模块说明


### PR DESCRIPTION
## Summary
- clarify how to use a proxy when compiling the frontend
- mention HTTP/HTTPS proxy environment variables also apply to yarn and shadow-cljs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68556d79012083278b23290d296cc2b9