### PR TITLE
新增 setup 脚本

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,32 @@ clj -M:nrepl -P
 
 这些命令会分别准备 `:dev`、`:test`、`:lint` 与 `:nrepl` profile 需要的库，避免运行时再解析依赖。
 
+下面给出 `setup` 脚本的示例实现，供参考：
+
+```bash
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# 设置 Java 代理
+export JAVA_TOOL_OPTIONS='-Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080 -Dhttps.proxyHost=proxy -Dhttps.proxyPort=8080'
+
+# 安装前端依赖
+yarn install
+
+# 预先下载 Clojure 各 profile 所需依赖
+clj -M:dev -P
+clj -M:test -P
+clj -M:lint -P
+clj -M:nrepl -P
+
+# 下载 ClojureScript 编译所需的 jar 包
+npx shadow-cljs deps
+
+# 编译前端
+npx shadow-cljs compile app
+```
+
 
 ## 7. 权限与模块说明
 

--- a/setup
+++ b/setup
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# 设置 Java 代理
+export JAVA_TOOL_OPTIONS='-Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080 -Dhttps.proxyHost=proxy -Dhttps.proxyPort=8080'
+
+# 安装前端依赖
+yarn install
+
+# 预先下载 Clojure 各 profile 所需依赖
+clj -M:dev -P
+clj -M:test -P
+clj -M:lint -P
+clj -M:nrepl -P
+
+# 下载 ClojureScript 编译所需的 jar 包
+npx shadow-cljs deps
+
+# 编译前端
+npx shadow-cljs compile app


### PR DESCRIPTION
## Summary
- 修改 `setup` 脚本，将代理设置提前
- 在 `AGENTS.md` 中展示 `setup` 脚本内容

## Testing
- `clj -M:test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68557c322efc8327bf7a328d890dca82