### PR TITLE
完善知情同意书自动填写医生签名

### DIFF
--- a/resources/html/report/anesthesia_consent.html
+++ b/resources/html/report/anesthesia_consent.html
@@ -330,8 +330,21 @@
                 });
             };
 
+            const loadDoctor = () => {
+                fetch('/api/me')
+                  .then(r => r.ok ? r.json() : Promise.reject('no-doctor'))
+                  .then(({doctor}) => {
+                      const sign = doctor?.signature_b64 || doctor?.name;
+                      const el = container.querySelector('[data-field="doctor_sign"]');
+                      if (el && sign && el.innerHTML.trim() === '&nbsp;') {
+                          el.innerHTML = sign;
+                      }
+                  })
+                  .catch(() => {});
+            };
+
             const loadConsent = (info = {}) => {
-                if (!assessmentId) { fillFields(info); return; }
+                if (!assessmentId) { fillFields(info); loadDoctor(); return; }
                 fetch(`/api/consent-forms/${assessmentId}`)
                   .then(r => r.ok ? r.json() : {})
                   .then(consent => {
@@ -340,8 +353,9 @@
                       } else {
                           fillFields(info);
                       }
+                      loadDoctor();
                   })
-                  .catch(() => fillFields(info));
+                  .catch(() => { fillFields(info); loadDoctor(); });
             };
 
             const loadPatient = () => {

--- a/resources/html/report/pre_anesthesia_consent.html
+++ b/resources/html/report/pre_anesthesia_consent.html
@@ -212,8 +212,21 @@
                 });
             };
 
+            const loadDoctor = () => {
+                fetch('/api/me')
+                  .then(r => r.ok ? r.json() : Promise.reject('no-doctor'))
+                  .then(({doctor}) => {
+                      const sign = doctor?.signature_b64 || doctor?.name;
+                      const el = form.querySelector('[data-field="doctor"]');
+                      if (el && sign && el.innerHTML.trim() === '&nbsp;') {
+                          el.innerHTML = sign;
+                      }
+                  })
+                  .catch(() => {});
+            };
+
             const loadConsent = (info = {}) => {
-                if (!assessmentId) { fillFields(info); return; }
+                if (!assessmentId) { fillFields(info); loadDoctor(); return; }
                 fetch(`/api/consent-forms/${assessmentId}`)
                   .then(r => r.ok ? r.json() : {})
                   .then(consent => {
@@ -222,8 +235,9 @@
                       } else {
                           fillFields(info);
                       }
+                      loadDoctor();
                   })
-                  .catch(() => fillFields(info));
+                  .catch(() => { fillFields(info); loadDoctor(); });
             };
 
             const loadPatient = () => {

--- a/resources/html/report/sedation_consent.html
+++ b/resources/html/report/sedation_consent.html
@@ -302,8 +302,21 @@
                 });
             };
 
+            const loadDoctor = () => {
+                fetch('/api/me')
+                  .then(r => r.ok ? r.json() : Promise.reject('no-doctor'))
+                  .then(({doctor}) => {
+                      const sign = doctor?.signature_b64 || doctor?.name;
+                      const el = form.querySelector('[data-field="doctor"]');
+                      if (el && sign && el.innerHTML.trim() === '&nbsp;') {
+                          el.innerHTML = sign;
+                      }
+                  })
+                  .catch(() => {});
+            };
+
             const loadConsent = (info = {}) => {
-                if (!assessmentId) { fillFields(info); return; }
+                if (!assessmentId) { fillFields(info); loadDoctor(); return; }
                 fetch(`/api/consent-forms/${assessmentId}`)
                   .then(r => r.ok ? r.json() : {})
                   .then(consent => {
@@ -312,8 +325,9 @@
                       } else {
                           fillFields(info);
                       }
+                      loadDoctor();
                   })
-                  .catch(() => fillFields(info));
+                  .catch(() => { fillFields(info); loadDoctor(); });
             };
 
             const loadPatient = () => {


### PR DESCRIPTION
## 变更内容
- 在三份知情同意书模板中新增 `loadDoctor` 函数，页面加载时从 `/api/me` 获取医生签名
- 若签名位置为空，则自动填充医生签名或姓名

## 测试情况
- 执行 `clojure -M:test`，因环境缺少 ClojureScript 相关依赖导致测试失败

------
https://chatgpt.com/codex/tasks/task_e_685608474410832795cf5590a058e77e