### PR TITLE
添加 cloverage 覆盖率功能

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,8 @@ repl:
 test:
         clj -M:test
 
+coverage:
+        clj -M:coverage
+
 uberjar:
 	clj -T:build all

--- a/deps.edn
+++ b/deps.edn
@@ -80,7 +80,25 @@
                   :main-opts   ["-e" "(require 'pjstadig.humane-test-output) (pjstadig.humane-test-output/activate!)"
                                 "-m" "kaocha.runner"]}
           :lint {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2025.06.05"}}
-                 :main-opts ["-m" "clj-kondo.main"]}}
+                 :main-opts ["-m" "clj-kondo.main"]}
+          :coverage {:extra-deps {cloverage/cloverage {:mvn/version "1.2.4"}
+                                 criterium/criterium {:mvn/version "0.4.6"}
+                                 expound/expound {:mvn/version "0.9.0"}
+                                 integrant/repl {:mvn/version "0.3.3"}
+                                 pjstadig/humane-test-output {:mvn/version "0.11.0"}
+                                 ring/ring-devel {:mvn/version "1.11.0"}
+                                 ring/ring-mock {:mvn/version "0.4.0"}
+                                 io.github.kit-clj/kit-generator {:mvn/version "0.2.5"}
+                                 org.clojure/tools.namespace {:mvn/version "1.4.5"}
+                                 peridot/peridot {:mvn/version "0.5.4"}
+                                 org.clj-commons/byte-streams {:mvn/version "0.3.4"}
+                                 com.lambdaisland/classpath {:mvn/version "0.5.48"}
+                                 com.gfredericks/test.chuck {:mvn/version "0.2.15"}
+                                 lambdaisland/kaocha-cljs {:mvn/version "1.0.107"}
+                                 lambdaisland/kaocha-cljs2 {:mvn/version "0.2.72"}
+                                 lambdaisland/funnel {:mvn/version "1.6.93"}}
+                     :extra-paths ["env/dev/clj" "env/dev/resources" "env/test/resources" "test/clj"]
+                     :main-opts ["-m" "cloverage.coverage" "--src-ns-path" "src/clj" "--test-ns-path" "test/clj"]}}
  :mvn/repos
  {"clojars" {:url "https://repo.clojars.org/"}
   "central" {:url "https://repo1.maven.org/maven2/"}

--- a/readme.org
+++ b/readme.org
@@ -346,6 +346,15 @@
 
    建议在进一步开发或部署前调查并解决这些测试问题，以确保后端代码的稳定性和正确性。
 
+** 4. 生成测试覆盖率 (Cloverage)
+   使用 Cloverage 可以查看后端代码的测试覆盖率：
+   #+BEGIN_SRC bash
+   clj -M:coverage
+   # 或者
+   make coverage
+   #+END_SRC
+   生成的报告位于 `target/coverage` 目录。
+
 * 构建和部署
 ** 构建 Uberjar (独立 Jar 包)
    #+BEGIN_SRC bash


### PR DESCRIPTION
## Summary
- 增加 `:coverage` alias 以支持 cloverage
- 在 Makefile 中加入 `coverage` 目标
- 更新文档说明如何生成测试覆盖率

## Testing
- `clojure -M:test`
- `clojure -M:coverage`
- `clojure -M:lint --lint deps.edn`


------
https://chatgpt.com/codex/tasks/task_e_68562404d31083279f5c1e3655e8467a