### PR TITLE
提高路由工具测试覆盖率

### DIFF
--- a/test/clj/hc/hospital/logging_test.clj
+++ b/test/clj/hc/hospital/logging_test.clj
@@ -1,0 +1,23 @@
+(ns hc.hospital.logging-test
+  (:require [clojure.test :refer :all]
+            [clojure.java.io :as io]
+            [hc.hospital.logging :as log])
+  (:import [java.time Instant ZoneId]
+           [java.time.format DateTimeFormatter]
+           [java.nio.file Files]))
+
+(deftest daily-file-appender-writes-log
+  (let [tmp-dir (.toString (Files/createTempDirectory "log-test" (make-array java.nio.file.attribute.FileAttribute 0)))
+        inst (Instant/parse "2025-01-01T12:00:00Z")
+        app-fn (:fn (log/daily-file-appender {:dir tmp-dir :prefix "test" :async? false}))
+        msg "hello\n"
+        date (.format (.atZone inst (ZoneId/systemDefault)) (DateTimeFormatter/ofPattern "yyyy-MM-dd"))
+        expected-path (str tmp-dir "/test-" date ".log")]
+    (try
+      (app-fn {:timestamp_ (delay inst) :output_ (delay msg)})
+      (is (.exists (io/file expected-path)))
+      (is (= msg (slurp expected-path)))
+      (finally
+        (io/delete-file expected-path true)
+        (io/delete-file tmp-dir true))))
+)

--- a/test/clj/hc/hospital/web/middleware/auth_test.clj
+++ b/test/clj/hc/hospital/web/middleware/auth_test.clj
@@ -1,0 +1,23 @@
+(ns hc.hospital.web.middleware.auth-test
+  (:require [clojure.test :refer :all]
+            [ring.mock.request :as mock]
+            [hc.hospital.web.middleware.auth :as auth]))
+
+(deftest on-error-redirects-to-login
+  (let [req (mock/request :get "/secret")
+        resp (auth/on-error req nil)]
+    (is (= 302 (:status resp)))
+    (is (= "/login" (get-in resp [:headers "Location"])))
+    (is (= "Access to /secret is not authorized. Please log in." (-> resp :flash :error)))))
+
+(deftest wrap-restricted-requires-authentication
+  (let [handler (constantly {:status 200 :body "ok"})
+        restricted (auth/wrap-restricted handler)]
+    (testing "unauthenticated request gets redirected"
+      (let [resp (restricted (mock/request :get "/"))]
+        (is (= 302 (:status resp)))))
+    (testing "authenticated request passes through"
+      (let [resp (restricted (-> (mock/request :get "/")
+                                 (assoc :identity {:user "bob"})))]
+        (is (= 200 (:status resp)))
+        (is (= "ok" (:body resp)))))))

--- a/test/clj/hc/hospital/web/middleware/core_test.clj
+++ b/test/clj/hc/hospital/web/middleware/core_test.clj
@@ -1,0 +1,18 @@
+(ns hc.hospital.web.middleware.core-test
+  (:require [clojure.test :refer :all]
+            [clojure.string :as str]
+            [hc.hospital.web.middleware.core :as core]))
+
+(deftest wrap-force-logout-cookie-test
+  (let [attrs {:path "/" :http-only true :same-site :strict :secure false}
+        logout-handler (fn [_] {:status 200 :body "bye" ::core/force-expire-cookie true})
+        wrapped (core/wrap-force-logout-cookie logout-handler "hc.hospital" attrs)
+        resp (wrapped {})]
+    (is (= 200 (:status resp)))
+    (is (= "" (get-in resp [:cookies "hc.hospital" :value])))
+    (is (= 0 (get-in resp [:cookies "hc.hospital" :max-age])))
+    (is (= "Thu, 01 Jan 1970 00:00:00 GMT" (get-in resp [:cookies "hc.hospital" :expires])))
+    (let [header (get-in resp [:headers "Set-Cookie"])
+          header-str (if (vector? header) (str/join ";" header) header)]
+      (is (str/includes? header-str "Max-Age=0"))
+      (is (str/includes? header-str "Expires=Thu, 01 Jan 1970 00:00:00 GMT")))))

--- a/test/clj/hc/hospital/web/middleware/exception_test.clj
+++ b/test/clj/hc/hospital/web/middleware/exception_test.clj
@@ -1,0 +1,20 @@
+(ns hc.hospital.web.middleware.exception-test
+  (:require [clojure.test :refer :all]
+            [hc.hospital.web.middleware.exception :as exc]))
+
+(defn apply-mw [mw handler]
+  ((:wrap mw) handler))
+
+(deftest wrap-exception-handles-known-types
+  (let [handler (fn [_] (throw (ex-info "boom" {:type :system.exception/not-found})))
+        wrapped (apply-mw exc/wrap-exception handler)
+        resp (wrapped {:uri "/missing"})]
+    (is (= 404 (:status resp)))
+    (is (= "not found" (get-in resp [:body :message])))))
+
+(deftest wrap-exception-handles-default
+  (let [handler (fn [_] (throw (ex-info "boom" {})))
+        wrapped (apply-mw exc/wrap-exception handler)
+        resp (wrapped {:uri "/"})]
+    (is (= 500 (:status resp)))
+    (is (= "default" (get-in resp [:body :message])))))

--- a/test/clj/hc/hospital/web/pages/layout_test.clj
+++ b/test/clj/hc/hospital/web/pages/layout_test.clj
@@ -1,0 +1,14 @@
+(ns hc.hospital.web.pages.layout-test
+  (:require [clojure.test :refer :all]
+            [hc.hospital.web.pages.layout :as layout]))
+
+(deftest render-produces-html-response
+  (let [resp (layout/render {} "home.html")]
+    (is (= 200 (:status resp)))
+    (is (= "text/html; charset=utf-8" (get-in resp [:headers "Content-Type"])))
+    (is (.contains (:body resp) "<!DOCTYPE html>"))))
+
+(deftest error-page-produces-html
+  (let [resp (layout/error-page {:status 404 :title "Not Found" :message "oops"})]
+    (is (= 404 (:status resp)))
+    (is (.contains (:body resp) "Not Found"))))

--- a/test/clj/hc/hospital/web/routes/pages_test.clj
+++ b/test/clj/hc/hospital/web/routes/pages_test.clj
@@ -1,0 +1,16 @@
+(ns hc.hospital.web.routes.pages-test
+  (:require [clojure.test :refer :all]
+            [hc.hospital.web.routes.pages :as pages]
+            [hc.hospital.web.middleware.exception :as exception]))
+
+(deftest page-routes-structure
+  (let [routes (pages/page-routes {})]
+    (is (= 3 (count routes)))
+    (is (= "/" (first (first routes))))
+    (is (= "/login" (first (second routes))))
+    (is (= "/logout" (first (nth routes 2))))))
+
+(deftest route-data-contains-middlewares
+  (is (vector? (:middleware pages/route-data)))
+  (is (fn? (first (:middleware pages/route-data))))
+  (is (some #{exception/wrap-exception} (:middleware pages/route-data))))

--- a/test/clj/hc/hospital/web/routes/utils_test.clj
+++ b/test/clj/hc/hospital/web/routes/utils_test.clj
@@ -1,0 +1,9 @@
+(ns hc.hospital.web.routes.utils-test
+  (:require [clojure.test :refer :all]
+            [hc.hospital.web.routes.utils :as utils]))
+
+(deftest route-data-utils
+  (let [req {:reitit.core/match {:data {:role :doctor :page "index"}}}]
+    (is (= {:role :doctor :page "index"} (utils/route-data req)))
+    (is (= :doctor (utils/route-data-key req :role)))
+    (is (nil? (utils/route-data-key req :missing)))))


### PR DESCRIPTION
## Summary
- 添加 `hc.hospital.web.routes.utils` 的测试
- 新增日志模块 `daily-file-appender` 的输出测试
- 新增中间件 `wrap-force-logout-cookie` 的单元测试
- 新增 `wrap-exception`、`wrap-restricted`、`render` 等更多测试

## Testing
- `clojure -M:test`
- `clojure -M:lint --lint test/clj/hc/hospital/web/middleware/auth_test.clj test/clj/hc/hospital/web/middleware/exception_test.clj test/clj/hc/hospital/web/pages/layout_test.clj test/clj/hc/hospital/web/routes/pages_test.clj`
- `clojure -M:coverage`


------
https://chatgpt.com/codex/tasks/task_e_6856284533f483279a3809ad87aca3c1